### PR TITLE
fix - Docker update to link libs and utils on build

### DIFF
--- a/consumer/Dockerfile
+++ b/consumer/Dockerfile
@@ -1,13 +1,26 @@
 FROM golang
 
 RUN mkdir -p /go/src/github.com/wednesday-solutions/go-template-consumer
+RUN mkdir -p /go/src/github.com/wednesday-solutions/libs
+RUN mkdir -p /go/src/github.com/wednesday-solutions/utils
 
-RUN go get -v github.com/rubenv/sql-migrate/... \
-  github.com/volatiletech/sqlboiler \
-  github.com/99designs/gqlgen
+RUN [ "go", "install", "github.com/rubenv/sql-migrate/...@latest"]
 
-ADD . /go/src/github.com/wednesday-solutions/go-template-consumer
-WORKDIR /go/src/github.com/wednesday-solutions/go-template-consumer
+ADD ./libs /go/src/github.com/wednesday-solutions/libs
+ADD ./utils /go/src/github.com/wednesday-solutions/utils
+ADD ./consumer /go/src/github.com/wednesday-solutions/go-template-consumer
+
+WORKDIR /go/src/github.com/wednesday-solutions/libs
+RUN GOARCH=amd64 \
+    GOOS=linux \
+    CGO_ENABLED=0 \
+    go mod vendor
+WORKDIR /go/src/github.com/wednesday-solutions/utils
+RUN GOARCH=amd64 \
+    GOOS=linux \
+    CGO_ENABLED=0 \
+    go mod vendor
+WORKDIR ../go-template-consumer
 
 RUN GOARCH=amd64 \
     GOOS=linux \

--- a/consumer/Dockerfile
+++ b/consumer/Dockerfile
@@ -5,6 +5,8 @@ RUN mkdir -p /go/src/github.com/wednesday-solutions/libs
 RUN mkdir -p /go/src/github.com/wednesday-solutions/utils
 
 RUN [ "go", "install", "github.com/rubenv/sql-migrate/...@latest"]
+RUN [ "go", "install", "github.com/volatiletech/sqlboiler@v3.7.1"]
+RUN [ "go", "install", "github.com/99designs/gqlgen@v0.14.0"]
 
 ADD ./libs /go/src/github.com/wednesday-solutions/libs
 ADD ./utils /go/src/github.com/wednesday-solutions/utils

--- a/consumer/docker-compose.yml
+++ b/consumer/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   db:
@@ -12,9 +12,11 @@ services:
       - POSTGRES_PORT=${DB_PORT}
       - POSTGRES_DB=${DB_NAME}
 
-
   app:
-    build: .
+    build:
+      context: ../
+      dockerfile: ./consumer/Dockerfile
+
     restart: always
     env_file:
       - ./.env.docker
@@ -23,6 +25,4 @@ services:
     ports:
       - ${SERVER_PORT}:${SERVER_PORT}
     environment:
-      ENVIRONMENT_NAME: 'docker'
-
-   
+      ENVIRONMENT_NAME: "docker"

--- a/producer/Dockerfile
+++ b/producer/Dockerfile
@@ -5,6 +5,8 @@ RUN mkdir -p /go/src/github.com/wednesday-solutions/libs
 RUN mkdir -p /go/src/github.com/wednesday-solutions/utils
 
 RUN [ "go", "install", "github.com/rubenv/sql-migrate/...@latest"]
+RUN [ "go", "install", "github.com/volatiletech/sqlboiler@v3.7.1"]
+RUN [ "go", "install", "github.com/99designs/gqlgen@v0.14.0"]
 
 ADD ./libs /go/src/github.com/wednesday-solutions/libs
 ADD ./utils /go/src/github.com/wednesday-solutions/utils

--- a/producer/Dockerfile
+++ b/producer/Dockerfile
@@ -1,13 +1,26 @@
 FROM golang
 
 RUN mkdir -p /go/src/github.com/wednesday-solutions/go-template-producer
+RUN mkdir -p /go/src/github.com/wednesday-solutions/libs
+RUN mkdir -p /go/src/github.com/wednesday-solutions/utils
 
-RUN go get -v github.com/rubenv/sql-migrate/... \
-  github.com/volatiletech/sqlboiler \
-  github.com/99designs/gqlgen
+RUN [ "go", "install", "github.com/rubenv/sql-migrate/...@latest"]
 
-ADD . /go/src/github.com/wednesday-solutions/go-template-producer
-WORKDIR /go/src/github.com/wednesday-solutions/go-template-producer
+ADD ./libs /go/src/github.com/wednesday-solutions/libs
+ADD ./utils /go/src/github.com/wednesday-solutions/utils
+ADD ./producer /go/src/github.com/wednesday-solutions/go-template-producer
+
+WORKDIR /go/src/github.com/wednesday-solutions/libs
+RUN GOARCH=amd64 \
+    GOOS=linux \
+    CGO_ENABLED=0 \
+    go mod vendor
+WORKDIR /go/src/github.com/wednesday-solutions/utils
+RUN GOARCH=amd64 \
+    GOOS=linux \
+    CGO_ENABLED=0 \
+    go mod vendor
+WORKDIR ../go-template-producer
 
 RUN GOARCH=amd64 \
     GOOS=linux \

--- a/producer/docker-compose.yml
+++ b/producer/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   db:
@@ -12,7 +12,10 @@ services:
       - POSTGRES_PORT=${DB_PORT}
       - POSTGRES_DB=${DB_NAME}
   app:
-    build: .
+    build:
+      context: ../
+      dockerfile: ./producer/Dockerfile
+
     restart: always
     env_file:
       - ./.env.docker
@@ -21,6 +24,4 @@ services:
     ports:
       - ${SERVER_PORT}:${SERVER_PORT}
     environment:
-      ENVIRONMENT_NAME: 'docker'
-
-   
+      ENVIRONMENT_NAME: "docker"


### PR DESCRIPTION
### Description
---------------------------------------------------
1. `golang` image for the containers use the latest image, and since `go 1.17` does not support `go get ` CD was failing. ` updated the Dockerfile to use `go install`
2. Since the `libs` module is linked locally, updated the docker-compose definitions to include the parent folder in the build context. Also updated the Dockerfile to ADD and Create folders for `libs` and `utils`.
